### PR TITLE
Better shader chunking and delayed decompression

### DIFF
--- a/ShaderGenerator/IO.cpp
+++ b/ShaderGenerator/IO.cpp
@@ -1,0 +1,50 @@
+#include "pch.h"
+#include "IO.h"
+
+using namespace std;
+using namespace std::filesystem;
+
+namespace ShaderGenerator
+{
+  std::string ReadAllText(const std::filesystem::path& path)
+  {
+    FILE* file = nullptr;
+    _wfopen_s(&file, path.c_str(), L"rb");
+    if (!file) return "";
+
+    fseek(file, 0, SEEK_END);
+    auto length = ftell(file);
+
+    string buffer(length, '\0');
+
+    fseek(file, 0, SEEK_SET);
+    fread_s(buffer.data(), length, length, 1, file);
+    fclose(file);
+
+    return buffer;
+  }
+
+  bool WriteAllText(const std::filesystem::path& path, const std::string& text)
+  {
+    FILE* file = nullptr;
+    _wfopen_s(&file, path.c_str(), L"wb");
+    if (!file) return false;
+
+    fwrite(text.data(), 1, text.size(), file);
+    fclose(file);
+
+    return true;
+  }
+
+  bool WriteAllBytes(const path& path, const vector<uint8_t>& bytes)
+  {
+    ofstream stream(path, ios::out | ios::binary);
+
+    if (stream.good())
+    {
+      stream.write((const char*)bytes.data(), bytes.size());
+    }
+
+    return stream.good();
+  }
+}

--- a/ShaderGenerator/IO.h
+++ b/ShaderGenerator/IO.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "pch.h"
+
+namespace ShaderGenerator
+{
+  std::string ReadAllText(const std::filesystem::path& path);
+  bool WriteAllText(const std::filesystem::path& path, const std::string& text);
+
+  bool WriteAllBytes(const std::filesystem::path& path, const std::vector<uint8_t>& bytes);
+}

--- a/ShaderGenerator/ShaderCompilationArguments.h
+++ b/ShaderGenerator/ShaderCompilationArguments.h
@@ -12,6 +12,7 @@ namespace ShaderGenerator
     std::string NamespaceName;
     bool WaitForDebugger = false;
 
+
     static ShaderCompilationArguments Parse(int argc, char* argv[]);
   };
 }

--- a/ShaderGenerator/ShaderCompiler.cpp
+++ b/ShaderGenerator/ShaderCompiler.cpp
@@ -10,22 +10,18 @@ namespace ShaderGenerator
   {
     const ShaderInfo* Shader;
     const ShaderCompilationArguments* Options;
-    queue<const OptionPermutation*> Input;
+    const vector<OptionPermutation>* Input;
     bool IsFailed = false;
 
-    mutex InputMutex, OutputMutex, MessagesMutex;
+    mutex MessagesMutex;
     vector<CompiledShader> Output;
     unordered_set<string> Messages;
 
     ShaderCompilationContext(const ShaderInfo& info, const ShaderCompilationArguments& options, const vector<OptionPermutation>& permutations) :
       Shader(&info),
-      Options(&options)
-    {
-      for (auto& permutation : permutations)
-      {
-        Input.push(&permutation);
-      }
-    }
+      Options(&options),
+      Input(&permutations)
+    { }
   };
 
   struct ShaderDebugName
@@ -34,135 +30,115 @@ namespace ShaderGenerator
     uint16_t NameLength;
   };
 
-  DWORD WINAPI CompileWorker(LPVOID contextPtr)
+  CompiledShader CompileWorker(const OptionPermutation& permutation, ShaderCompilationContext& context)
   {
-    ShaderCompilationContext& context = *((ShaderCompilationContext*)contextPtr);
+    //Define result
+    CompiledShader result{};
+    result.Key = permutation.Key;
 
-    while (true)
+    //Define macros
+    vector<D3D_SHADER_MACRO> macros;
+    for (auto& define : permutation.Defines)
     {
-      //Get work item
-      const OptionPermutation* permutation;
+      macros.push_back({ define.first.c_str(), define.second.c_str() });
+    }
+    macros.push_back({ nullptr, nullptr });
+
+    //Define compilation flags
+    auto flags = 0u;
+    if (context.Options->IsDebug)
+    {
+      flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_DEBUG_NAME_FOR_BINARY;
+    }
+
+    switch (context.Options->OptimizationLevel)
+    {
+    case -1:
+      flags |= D3DCOMPILE_SKIP_OPTIMIZATION;
+      break;
+    case 0:
+      flags |= D3DCOMPILE_OPTIMIZATION_LEVEL0;
+      break;
+    case 1:
+      flags |= D3DCOMPILE_OPTIMIZATION_LEVEL1;
+      break;
+    case 2:
+      flags |= D3DCOMPILE_OPTIMIZATION_LEVEL2;
+      break;
+    case 3:
+      flags |= D3DCOMPILE_OPTIMIZATION_LEVEL3;
+      break;
+    }
+
+    //Run compilation
+    com_ptr<ID3DBlob> binary, errors;
+    auto success = SUCCEEDED(D3DCompileFromFile(
+      context.Shader->Path.c_str(),
+      macros.data(),
+      D3D_COMPILE_STANDARD_FILE_INCLUDE,
+      context.Shader->EntryPoint.c_str(),
+      context.Shader->Target.c_str(),
+      flags,
+      0u,
+      binary.put(),
+      errors.put()));
+
+    //Post process results
+    if (success)
+    {
+      //Get debug information
+      if(context.Options->IsDebug && context.Options->UseExternalDebugSymbols)
       {
-        lock_guard<mutex> lock(context.InputMutex);
-        if (context.Input.empty()) return 0;
+        com_ptr<ID3DBlob> pdb;
+        D3DGetBlobPart(binary->GetBufferPointer(), binary->GetBufferSize(), D3D_BLOB_PDB, 0, pdb.put());
 
-        permutation = context.Input.front();
-        context.Input.pop();
-      }
+        com_ptr<ID3DBlob> pdbName;
+        D3DGetBlobPart(binary->GetBufferPointer(), binary->GetBufferSize(), D3D_BLOB_DEBUG_NAME, 0, pdbName.put());
 
-      //Define result
-      CompiledShader result{};
-      result.Key = permutation->Key;
-
-      //Define macros
-      vector<D3D_SHADER_MACRO> macros;
-      for (auto& define : permutation->Defines)
-      {
-        macros.push_back({ define.first.c_str(), define.second.c_str() });
-      }
-      macros.push_back({ nullptr, nullptr });
-
-      //Define compilation flags
-      auto flags = 0u;
-      if (context.Options->IsDebug)
-      {
-        flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_DEBUG_NAME_FOR_BINARY;
-      }
-
-      switch (context.Options->OptimizationLevel)
-      {
-      case -1:
-        flags |= D3DCOMPILE_SKIP_OPTIMIZATION;
-        break;
-      case 0:
-        flags |= D3DCOMPILE_OPTIMIZATION_LEVEL0;
-        break;
-      case 1:
-        flags |= D3DCOMPILE_OPTIMIZATION_LEVEL1;
-        break;
-      case 2:
-        flags |= D3DCOMPILE_OPTIMIZATION_LEVEL2;
-        break;
-      case 3:
-        flags |= D3DCOMPILE_OPTIMIZATION_LEVEL3;
-        break;
-      }
-
-      //Run compilation
-      com_ptr<ID3DBlob> binary, errors;
-      auto success = SUCCEEDED(D3DCompileFromFile(
-        context.Shader->Path.c_str(),
-        macros.data(),
-        D3D_COMPILE_STANDARD_FILE_INCLUDE,
-        context.Shader->EntryPoint.c_str(),
-        context.Shader->Target.c_str(),
-        flags,
-        0u,
-        binary.put(),
-        errors.put()));
-
-      //Post process results
-      if (success)
-      {
-        //Get debug information
-        if(context.Options->IsDebug && context.Options->UseExternalDebugSymbols)
+        if (pdb && pdbName)
         {
-          com_ptr<ID3DBlob> pdb;
-          D3DGetBlobPart(binary->GetBufferPointer(), binary->GetBufferSize(), D3D_BLOB_PDB, 0, pdb.put());
+          auto pDebugNameData = reinterpret_cast<const ShaderDebugName*>(pdbName->GetBufferPointer());
+          auto fileName = reinterpret_cast<const char*>(pDebugNameData + 1);
 
-          com_ptr<ID3DBlob> pdbName;
-          D3DGetBlobPart(binary->GetBufferPointer(), binary->GetBufferSize(), D3D_BLOB_DEBUG_NAME, 0, pdbName.put());
-
-          if (pdb && pdbName)
-          {
-            auto pDebugNameData = reinterpret_cast<const ShaderDebugName*>(pdbName->GetBufferPointer());
-            auto fileName = reinterpret_cast<const char*>(pDebugNameData + 1);
-
-            result.PdbName = fileName;
-            result.PdbData.resize(pdb->GetBufferSize());
-            memcpy(result.PdbData.data(), pdb->GetBufferPointer(), pdb->GetBufferSize());
-          }
-
-          com_ptr<ID3DBlob> stripped;
-          D3DStripShader(binary->GetBufferPointer(), binary->GetBufferSize(), D3DCOMPILER_STRIP_DEBUG_INFO, stripped.put());
-          swap(binary, stripped);
+          result.PdbName = fileName;
+          result.PdbData.resize(pdb->GetBufferSize());
+          memcpy(result.PdbData.data(), pdb->GetBufferPointer(), pdb->GetBufferSize());
         }
 
-        //Save binary
-        {
-          result.Data.resize(binary->GetBufferSize());
-          memcpy(result.Data.data(), binary->GetBufferPointer(), binary->GetBufferSize());
-        }
+        com_ptr<ID3DBlob> stripped;
+        D3DStripShader(binary->GetBufferPointer(), binary->GetBufferSize(), D3DCOMPILER_STRIP_DEBUG_INFO, stripped.put());
+        swap(binary, stripped);
       }
+
+      //Save binary
+      {
+        result.Data.resize(binary->GetBufferSize());
+        memcpy(result.Data.data(), binary->GetBufferPointer(), binary->GetBufferSize());
+      }
+    }
       
-      //Print out messages
-      stringstream messages{ string((char*)errors->GetBufferPointer(), size_t(errors->GetBufferSize())) };
-      string message;
-      static regex warningIgnoreRegex(".*: warning X3568: '(target|namespace|entry|option)' : unknown pragma ignored");
+    //Print out messages
+    stringstream messages{ string((char*)errors->GetBufferPointer(), size_t(errors->GetBufferSize())) };
+    string message;
+    static regex warningIgnoreRegex(".*: warning X3568: '(target|namespace|entry|option)' : unknown pragma ignored");
+    {
+      while (getline(messages, message, '\n'))
       {
-        while (getline(messages, message, '\n'))
+        if (!regex_match(message, warningIgnoreRegex) && context.Messages.emplace(message).second)
         {
-          if (!regex_match(message, warningIgnoreRegex) && context.Messages.emplace(message).second)
-          {
-            lock_guard<mutex> lock(context.MessagesMutex);
-            printf("%s\n", message.c_str());
-          }
+          lock_guard<mutex> lock(context.MessagesMutex);
+          printf("%s\n", message.c_str());
         }
-      }
-
-      //If successful return binary
-      if (success)
-      {
-        lock_guard<mutex> lock(context.OutputMutex);        
-        context.Output.push_back(move(result));
-      }
-      else
-      {
-        context.IsFailed = true;
       }
     }
 
-    return 0;
+    //If not successful set failed flag
+    if (!success)
+    {
+      context.IsFailed = true;
+    }
+
+    return result;
   }
 
   vector<CompiledShader> ShaderGenerator::CompileShader(const ShaderInfo& shader, const ShaderCompilationArguments& options)
@@ -174,14 +150,14 @@ namespace ShaderGenerator
     if (options.IsDebug) printf(" with debug symbols");
     printf("...\n Generating %zu shader variants.\n", permutations.size());
 
-    auto threadCount = min(thread::hardware_concurrency(), permutations.size());
-    vector<HANDLE> threads(threadCount);
-    for (auto& thread : threads)
-    {
-      thread = CreateThread(nullptr, 0, &CompileWorker, &context, 0, nullptr);
-    }
+    context.Output.resize(context.Input->size());
+    transform(execution::par, context.Input->begin(), context.Input->end(), context.Output.begin(), 
+      [&](const OptionPermutation& permutation) 
+      { 
+        return CompileWorker(permutation, context); 
+      }
+    );
 
-    WaitForMultipleObjects(DWORD(threads.size()), threads.data(), true, INFINITE);
     if (context.IsFailed)
     {
       printf("Shader group compilation failed.\n");

--- a/ShaderGenerator/ShaderCompiler.cpp
+++ b/ShaderGenerator/ShaderCompiler.cpp
@@ -24,13 +24,7 @@ namespace ShaderGenerator
     { }
   };
 
-  struct ShaderDebugName
-  {
-    uint16_t Flags;
-    uint16_t NameLength;
-  };
-
-  CompiledShader CompileWorker(const OptionPermutation& permutation, ShaderCompilationContext& context)
+  CompiledShader CompileShaderPermutation(const OptionPermutation& permutation, ShaderCompilationContext& context)
   {
     //Define result
     CompiledShader result{};
@@ -97,6 +91,12 @@ namespace ShaderGenerator
 
         if (pdb && pdbName)
         {
+          struct ShaderDebugName
+          {
+            uint16_t Flags;
+            uint16_t NameLength;
+          };
+
           auto pDebugNameData = reinterpret_cast<const ShaderDebugName*>(pdbName->GetBufferPointer());
           auto fileName = reinterpret_cast<const char*>(pDebugNameData + 1);
 
@@ -110,7 +110,7 @@ namespace ShaderGenerator
         swap(binary, stripped);
       }
 
-      //Save binary
+      //Store binary
       {
         result.Data.resize(binary->GetBufferSize());
         memcpy(result.Data.data(), binary->GetBufferPointer(), binary->GetBufferSize());
@@ -141,7 +141,7 @@ namespace ShaderGenerator
     return result;
   }
 
-  vector<CompiledShader> ShaderGenerator::CompileShader(const ShaderInfo& shader, const ShaderCompilationArguments& options)
+  vector<CompiledShader> CompileShader(const ShaderInfo& shader, const ShaderCompilationArguments& options)
   {
     auto permutations = ShaderOption::Permutate(shader.Options);
     ShaderCompilationContext context{shader, options, permutations};
@@ -154,7 +154,7 @@ namespace ShaderGenerator
     transform(execution::par, context.Input->begin(), context.Input->end(), context.Output.begin(), 
       [&](const OptionPermutation& permutation) 
       { 
-        return CompileWorker(permutation, context); 
+        return CompileShaderPermutation(permutation, context); 
       }
     );
 

--- a/ShaderGenerator/ShaderConfiguration.cpp
+++ b/ShaderGenerator/ShaderConfiguration.cpp
@@ -201,11 +201,18 @@ namespace ShaderGenerator
       return { {} };
     }
 
-    std::vector<size_t> indices(options.size());
-    size_t currentIndex = 0;
+    vector<size_t> indices(options.size());
+    size_t currentIndex = indices.size()-1;
     auto done = false;
 
+    size_t permutationCount = 1;
+    for (auto& option : options)
+    {
+      permutationCount *= option->ValueCount();
+    }
+
     vector<OptionPermutation> results;
+    results.reserve(permutationCount);
 
     while (!done)
     {
@@ -230,7 +237,7 @@ namespace ShaderGenerator
         value.Key |= indices[i] << offset;
         offset += option->KeyLength();
       }
-      results.push_back(value);
+      results.push_back(move(value));
 
       //Iterate
       indices[currentIndex]++;
@@ -238,21 +245,24 @@ namespace ShaderGenerator
       while (!done && indices[currentIndex] == options[currentIndex]->ValueCount())
       {
         roll = true;
-        currentIndex++;
-        if (currentIndex == indices.size())
+        if (currentIndex == 0)
         {
           done = true;
           continue;
         }
+        else
+        {
+          currentIndex--;
+        }
 
-        for (size_t i = 0; i < currentIndex; i++)
+        for (size_t i = currentIndex+1; i < indices.size(); i++)
         {
           indices[i] = 0;
         }
         indices[currentIndex]++;
       }
 
-      if (roll) currentIndex = 0;
+      if (roll) currentIndex = indices.size() - 1;
     }
 
     return results;

--- a/ShaderGenerator/ShaderConfiguration.cpp
+++ b/ShaderGenerator/ShaderConfiguration.cpp
@@ -62,7 +62,7 @@ namespace ShaderGenerator
   unordered_set<filesystem::path> GetDependencies(const std::filesystem::path& path)
   {
     static regex includeRegex("#include\\s+\"([^\"]*)\"");
-    
+
     queue<filesystem::path> dependenciesToCheck;
     dependenciesToCheck.push(path);
 
@@ -194,26 +194,37 @@ namespace ShaderGenerator
     return text.str();
   }
 
+  size_t ShaderOption::KeyLength() const
+  {
+    auto range = ValueCount();
+    return range > 0 ? (size_t)ceil(log2(float(range))) : 0;
+  }
+
   std::vector<OptionPermutation> ShaderOption::Permutate(const std::vector<std::unique_ptr<ShaderOption>>& options)
   {
+    //If there are no options, there is a single empty permutation
     if (options.empty())
     {
       return { {} };
     }
 
-    vector<size_t> indices(options.size());
-    size_t currentIndex = indices.size()-1;
-    auto done = false;
-
+    //Count permutations
     size_t permutationCount = 1;
     for (auto& option : options)
     {
       permutationCount *= option->ValueCount();
     }
 
+    //Create result buffer
     vector<OptionPermutation> results;
     results.reserve(permutationCount);
 
+    //Create index buffer
+    vector<size_t> indices(options.size());
+    size_t currentIndex = indices.size() - 1;
+
+    //Iterate permutations
+    auto done = false;
     while (!done)
     {
       //Emit result
@@ -226,7 +237,7 @@ namespace ShaderGenerator
         string definedValue;
         if (option->TryGetDefinedValue(indices[i], definedValue))
         {
-          value.Defines.push_back({ option->Name + definedValue, "1"});
+          value.Defines.push_back({ option->Name + definedValue, "1" });
 
           if (option->IsValueDefinedExplicitly())
           {
@@ -239,26 +250,29 @@ namespace ShaderGenerator
       }
       results.push_back(move(value));
 
-      //Iterate
+      //Increment indices
       indices[currentIndex]++;
+
       auto roll = false;
       while (!done && indices[currentIndex] == options[currentIndex]->ValueCount())
       {
         roll = true;
+
         if (currentIndex == 0)
         {
           done = true;
-          continue;
+          break;
         }
         else
         {
           currentIndex--;
         }
 
-        for (size_t i = currentIndex+1; i < indices.size(); i++)
+        for (size_t i = currentIndex + 1; i < indices.size(); i++)
         {
           indices[i] = 0;
         }
+
         indices[currentIndex]++;
       }
 
@@ -266,5 +280,84 @@ namespace ShaderGenerator
     }
 
     return results;
+  }
+
+  OptionType BooleanOption::Type() const
+  {
+    return OptionType::Boolean;
+  }
+
+  size_t BooleanOption::ValueCount() const
+  {
+    return 2;
+  }
+
+  bool BooleanOption::IsValueDefinedExplicitly() const
+  {
+    return false;
+  }
+
+  bool BooleanOption::TryGetDefinedValue(size_t index, std::string& value) const
+  {
+    value = "";
+    return index == 1;
+  }
+
+  OptionType EnumerationOption::Type() const
+  {
+    return OptionType::Enumeration;
+  }
+
+  size_t EnumerationOption::ValueCount() const
+  {
+    return Values.size();
+  }
+
+  bool EnumerationOption::IsValueDefinedExplicitly() const
+  {
+    return true;
+  }
+
+  bool EnumerationOption::TryGetDefinedValue(size_t index, std::string& value) const
+  {
+    if (index >= 0 && index < Values.size())
+    {
+      value = Values.at(index);
+      return true;
+    }
+    else
+    {
+      value = "";
+      return false;
+    }
+  }
+
+  OptionType IntegerOption::Type() const
+  {
+    return OptionType::Integer;
+  }
+
+  size_t IntegerOption::ValueCount() const
+  {
+    return size_t(Maximum - Minimum) + 1;
+  }
+
+  bool IntegerOption::IsValueDefinedExplicitly() const
+  {
+    return true;
+  }
+
+  bool IntegerOption::TryGetDefinedValue(size_t index, std::string& value) const
+  {
+    if (index >= 0 && index < ValueCount())
+    {
+      value = std::to_string(index + Minimum);
+      return true;
+    }
+    else
+    {
+      value = "";
+      return false;
+    }
   }
 }

--- a/ShaderGenerator/ShaderConfiguration.h
+++ b/ShaderGenerator/ShaderConfiguration.h
@@ -20,11 +20,7 @@ namespace ShaderGenerator
   {
     std::string Name;
     
-    virtual size_t KeyLength() const
-    {
-      auto range = ValueCount();
-      return range > 0 ? (size_t)ceil(log2(float(range))) : 0;
-    }
+    virtual size_t KeyLength() const;
 
     virtual OptionType Type() const = 0;
 
@@ -41,94 +37,39 @@ namespace ShaderGenerator
 
   struct BooleanOption : public ShaderOption
   {
-    virtual OptionType Type() const override
-    {
-      return OptionType::Boolean;
-    }
+    virtual OptionType Type() const override;
 
-    virtual size_t ValueCount() const override
-    {
-      return 2;
-    }
+    virtual size_t ValueCount() const override;
 
-    virtual bool IsValueDefinedExplicitly() const override
-    {
-      return false;
-    }
+    virtual bool IsValueDefinedExplicitly() const override;
 
-    virtual bool TryGetDefinedValue(size_t index, std::string& value) const override
-    {
-      value = "";
-      return index == 1;
-    }
+    virtual bool TryGetDefinedValue(size_t index, std::string& value) const override;
   };
 
   struct EnumerationOption : public ShaderOption
   {
     std::vector<std::string> Values;
 
-    virtual OptionType Type() const override
-    {
-      return OptionType::Enumeration;
-    }
+    virtual OptionType Type() const override;
 
-    virtual size_t ValueCount() const override
-    {
-      return Values.size();
-    }
+    virtual size_t ValueCount() const override;
 
-    virtual bool IsValueDefinedExplicitly() const override
-    {
-      return true;
-    }
+    virtual bool IsValueDefinedExplicitly() const override;
 
-    virtual bool TryGetDefinedValue(size_t index, std::string& value) const override
-    {
-      if (index >= 0 && index < Values.size())
-      {
-        value = Values.at(index);
-        return true;
-      }
-      else
-      {
-        value = "";
-        return false;
-      }
-    }
+    virtual bool TryGetDefinedValue(size_t index, std::string& value) const override;
   };
 
   struct IntegerOption : public ShaderOption
   {
     int Minimum, Maximum;
 
-    virtual OptionType Type() const override
-    {
-      return OptionType::Integer;
-    }
+    virtual OptionType Type() const override;
 
-    virtual size_t ValueCount() const override
-    {
-      return size_t(Maximum - Minimum) + 1;
-    }
+    virtual size_t ValueCount() const override;
 
-    virtual bool IsValueDefinedExplicitly() const override
-    {
-      return true;
-    }
+    virtual bool IsValueDefinedExplicitly() const override;
 
-    virtual bool TryGetDefinedValue(size_t index, std::string& value) const override
-    {
-      if (index >= 0 && index < ValueCount())
-      {
-        value = std::to_string(index + Minimum);
-        return true;
-      }
-      else
-      {
-        value = "";
-        return false;
-      }
-    }
+    virtual bool TryGetDefinedValue(size_t index, std::string& value) const override;
   };
 
   struct ShaderInfo

--- a/ShaderGenerator/ShaderGenerator.vcxproj
+++ b/ShaderGenerator/ShaderGenerator.vcxproj
@@ -71,10 +71,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(ProjectDir)bin\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(ProjectDir)bin\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(ProjectDir)obj\$(Configuration)\$(Platform)\</IntDir>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/ShaderGenerator/ShaderGenerator.vcxproj
+++ b/ShaderGenerator/ShaderGenerator.vcxproj
@@ -131,6 +131,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="FileAttributes.h" />
+    <ClInclude Include="IO.h" />
     <ClInclude Include="ShaderCompilationArguments.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ShaderCompiler.h" />
@@ -139,6 +140,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileAttributes.cpp" />
+    <ClCompile Include="IO.cpp" />
     <ClCompile Include="ShaderCompilationArguments.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="pch.cpp">

--- a/ShaderGenerator/ShaderGenerator.vcxproj.filters
+++ b/ShaderGenerator/ShaderGenerator.vcxproj.filters
@@ -19,6 +19,9 @@
     <ClInclude Include="FileAttributes.h">
       <Filter>Helpers</Filter>
     </ClInclude>
+    <ClInclude Include="IO.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -38,6 +41,9 @@
       <Filter>Helpers</Filter>
     </ClCompile>
     <ClCompile Include="FileAttributes.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="IO.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
   </ItemGroup>

--- a/ShaderGenerator/ShaderOutputWriter.cpp
+++ b/ShaderGenerator/ShaderOutputWriter.cpp
@@ -31,7 +31,7 @@ namespace ShaderGenerator
 
   struct ShaderBlockLayout
   {
-    inline static const size_t MaxBlockSize = 128;
+    inline static const size_t MaxBlockSize = 64;
 
     size_t BlockCount = 1ull;
     size_t BlockSize = 0ull;

--- a/ShaderGenerator/ShaderOutputWriter.cpp
+++ b/ShaderGenerator/ShaderOutputWriter.cpp
@@ -40,7 +40,7 @@ namespace ShaderGenerator
 
     ShaderBlockLayout(const ShaderInfo& info, size_t shaderVariationCount)
     {
-      if (shaderVariationCount < MaxBlockSize)
+      if (shaderVariationCount <= MaxBlockSize)
       {
         BlockSize = shaderVariationCount;
       }

--- a/ShaderGenerator/ShaderOutputWriter.cpp
+++ b/ShaderGenerator/ShaderOutputWriter.cpp
@@ -130,6 +130,8 @@ namespace ShaderGenerator
     {
       ShaderBlockLayout blockLayout{ shaderInfo, compiledShaders.size() };
 
+      wprintf(L"Layout: %zu block(s), %zu shader variants in each block.\n", blockLayout.BlockCount, blockLayout.BlockSize);
+
       //Define compression input
       vector<array_view<const CompiledShader>> input;
       input.reserve(blockLayout.BlockCount);

--- a/ShaderGenerator/ShaderOutputWriter.h
+++ b/ShaderGenerator/ShaderOutputWriter.h
@@ -3,7 +3,7 @@
 
 namespace ShaderGenerator
 {
-  void WriteShaderOutput(const std::filesystem::path& path, const std::vector<CompiledShader>& data);
+  void WriteShaderOutput(const std::filesystem::path& path, const std::vector<CompiledShader>& data, const ShaderInfo& shader);
 
   void WriteHeader(const ShaderCompilationArguments& path, const ShaderInfo& shader);
 }

--- a/ShaderGenerator/main.cpp
+++ b/ShaderGenerator/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
 
         if (!output.empty())
         {
-          WriteShaderOutput(arguments.Output, output);
+          WriteShaderOutput(arguments.Output, output, shader);
         }
       }
     }

--- a/ShaderGenerator/pch.h
+++ b/ShaderGenerator/pch.h
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <execution>
 
+#define NOMINMAX
+
 #include <Windows.h>
 #include <winrt/base.h>
 #include <winrt/Windows.Foundation.h>

--- a/ShaderGenerator/pch.h
+++ b/ShaderGenerator/pch.h
@@ -7,6 +7,8 @@
 #include <thread>
 #include <sstream>
 #include <unordered_set>
+#include <algorithm>
+#include <execution>
 
 #include <Windows.h>
 #include <winrt/base.h>

--- a/ShaderImporter/main.cpp
+++ b/ShaderImporter/main.cpp
@@ -28,7 +28,7 @@ int main()
     nullptr,
     context.put()));
   
-  auto shaderGroup = ShaderGenerator::CompiledShaderGroup::FromFile("G:\\cae\\dev\\ShaderCompiler\\ShaderImporter\\bin\\Debug\\x64\\ComputeShader.csg");
+  auto shaderGroup = ShaderGenerator::CompiledShaderGroup::FromFile("C:\\Users\\tsuhajda\\Downloads\\ShaderCompiler\\ShaderImporter\\bin\\Release\\x64\\ComputeShader.csg");
 
   auto shaderVariant = shaderGroup.Shader(ShaderImporter::Shaders::ComputeShaderFlags::BooleanOption);
   com_ptr<ID3D11ComputeShader> shader;

--- a/ShaderImporter/main.cpp
+++ b/ShaderImporter/main.cpp
@@ -3,6 +3,7 @@
 #include "ShaderGenerator.h"
 
 using namespace std;
+using namespace std::filesystem;
 using namespace winrt;
 using namespace DirectX;
 
@@ -10,6 +11,13 @@ int main()
 {
   init_apartment();
 
+  //Get application directory
+  wchar_t executablePath[MAX_PATH];
+  GetModuleFileName(NULL, executablePath, MAX_PATH);
+
+  auto applicationRoot = path(executablePath).parent_path();
+
+  //Create Direct3D 11 device
   D3D_FEATURE_LEVEL featureLevels[] = {
     D3D_FEATURE_LEVEL_11_0
   };
@@ -28,11 +36,16 @@ int main()
     nullptr,
     context.put()));
   
-  auto shaderGroup = ShaderGenerator::CompiledShaderGroup::FromFile("C:\\Users\\tsuhajda\\Downloads\\ShaderCompiler\\ShaderImporter\\bin\\Release\\x64\\ComputeShader.csg");
+  //Load shader from file
+  auto shaderGroup = ShaderGenerator::CompiledShaderGroup::FromFile(applicationRoot / "ComputeShader.csg");
 
+  //Select shader variant
   auto shaderVariant = shaderGroup.Shader(ShaderImporter::Shaders::ComputeShaderFlags::BooleanOption);
+
+  //Load shader on GPU
   com_ptr<ID3D11ComputeShader> shader;
   check_hresult(device->CreateComputeShader(shaderVariant->ByteCode.data(), shaderVariant->ByteCode.size(), nullptr, shader.put()));
 
+  //Print success message
   printf("Import works!\n");
 }

--- a/nuget/ShaderGenerator.nuspec
+++ b/nuget/ShaderGenerator.nuspec
@@ -5,7 +5,7 @@
     <id>ShaderGenerator</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.0.33.0</version>
+    <version>1.0.34.0</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Péter Major</authors>

--- a/nuget/include/ShaderGenerator.h
+++ b/nuget/include/ShaderGenerator.h
@@ -2,8 +2,8 @@
 #include <vector>
 #include <unordered_map>
 #include <filesystem>
-#include <fstream>
 #include <string>
+#include <mutex>
 #include <winrt/base.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.ApplicationModel.h>
@@ -16,44 +16,29 @@ namespace ShaderGenerator
 {
   struct CompiledShader
   {
-    uint64_t Key;
-    uint32_t Size;
+    uint64_t Key = 0ull;
+    uint32_t Size = 0u;
     std::vector<uint8_t> ByteCode;
-  };
-
-  struct BlockInfo
-  {
-    uint32_t ShaderCount = 0u;
-    size_t CompressedOffset = 0ull;
-  };
-
-  struct UncompressedBlock
-  {
-    uint64_t Index;
-    std::unordered_map<uint64_t, uint64_t> ShaderOffsets;
-    winrt::Windows::Storage::Streams::InMemoryRandomAccessStream Block;
   };
 
   class CompiledShaderGroup
   {
-  private:
-    //Bitmask used to obtain block key from a shader key
-    uint64_t _blockIndexMask = 0;
+#pragma region Helper types
+    struct ShaderBlockInfo
+    {
+      uint64_t CompressedOffset = 0ull;
+      uint32_t ShaderCount = 0u;
+    };
 
-    //All compressed blocks
-    winrt::Windows::Storage::Streams::IRandomAccessStream _compressedBlocks { nullptr };
+    struct ShaderBlock
+    {
+      uint64_t Key;
+      std::unordered_map<uint64_t, uint64_t> ShaderOffsets;
+      winrt::Windows::Storage::Streams::InMemoryRandomAccessStream Block;
+    };
+#pragma endregion
 
-    //Info about the compressed blocks 
-    std::unordered_map<uint64_t, BlockInfo> _blockInfos;
-
-    //Last uncompressed block
-    std::optional<UncompressedBlock> _uncompressedBlock;
-
-    //Cache for the uncompressed shaders
-    std::unordered_map<uint64_t, CompiledShader> _shadersByKey;
-
-    CompiledShaderGroup() = default;
-
+#pragma region Helper methods
     template <typename TAsync>
     static void AwaitOperation(TAsync const& async)
     {
@@ -74,119 +59,109 @@ namespace ShaderGenerator
     }
 
     template<typename T>
-    static T read_internal(winrt::Windows::Storage::Streams::DataReader& reader);
-
-    template<>
-    static uint32_t read_internal<uint32_t>(winrt::Windows::Storage::Streams::DataReader& reader)
-    {
-      return reader.ReadUInt32();
-    }
-
-    template<>
-    static uint64_t read_internal<uint64_t>(winrt::Windows::Storage::Streams::DataReader& reader)
-    {
-      return reader.ReadUInt64();
-    }
-
-    template<typename T>
-    static void read(winrt::Windows::Storage::Streams::DataReader& reader, T& value)
+    static void ReadValue(winrt::Windows::Storage::Streams::DataReader& reader, T& value)
     {
       static_assert(std::is_trivially_copyable_v<T>);
       AwaitOperation(reader.LoadAsync(sizeof(T)));
-      value = read_internal<T>(reader);
+      reader.ReadBytes({ reinterpret_cast<uint8_t*>(&value), sizeof(T) });
     }
 
-    static void read(winrt::Windows::Storage::Streams::DataReader& reader, std::vector<uint8_t>& value)
+    template<typename T>
+    static auto ReadValue(winrt::Windows::Storage::Streams::DataReader& reader)
+    {
+      T value{};
+      ReadValue(reader, value);
+      return value;
+    }
+
+    static void ReadVector(winrt::Windows::Storage::Streams::DataReader& reader, std::vector<uint8_t>& value)
     {
       AwaitOperation(reader.LoadAsync(uint32_t(value.size())));
       reader.ReadBytes(value);
     }
 
-    template<typename T>
-    static auto read(winrt::Windows::Storage::Streams::DataReader& reader)
-    {
-      T value{};
-      read(reader, value);
-      return value;
-    }
-
-    static auto read_string(winrt::Windows::Storage::Streams::DataReader& reader, uint32_t length)
+    static auto ReadString(winrt::Windows::Storage::Streams::DataReader& reader, uint32_t length)
     {
       AwaitOperation(reader.LoadAsync(length));
       return reader.ReadString(length);
     }
 
-    static CompiledShader read_shader(winrt::Windows::Storage::Streams::DataReader& reader, bool partial = false)
-    {
-      auto magic = read_string(reader, 4);
-      if (magic != L"SH01")
-      {
-        throw std::exception("Invalid compiled shader instance header.");
-      }
-
-      CompiledShader shader;
-      read(reader, shader.Key);
-      read(reader, shader.Size);
-
-      if (!partial)
-      {
-        shader.ByteCode.resize(shader.Size);
-        read(reader, shader.ByteCode);
-      }
-
-      return shader;
-    }
-    
     static bool IsUwp()
     {
       uint32_t length = 0;
       auto result = GetCurrentPackageFullName(&length, nullptr);
       return result == APPMODEL_ERROR_NO_PACKAGE ? false : true;
     }
+#pragma endregion
 
-    const CompiledShader* LoadFromUncompressedBlock(uint64_t key)
+  private:
+    //Bitmask used to obtain block key from a shader key
+    uint64_t _blockKeyMask = 0ull;
+
+    //The start position of the first block
+    uint64_t _blockOffset = 0ull;
+
+    //The backing shader stream
+    winrt::Windows::Storage::Streams::IRandomAccessStream _shaderStream{ nullptr };
+
+    //Info about the shader blocks 
+    std::unordered_map<uint64_t, ShaderBlockInfo> _shaderBlocks;
+
+    //The active shader block
+    std::optional<ShaderBlock> _activeBlock;
+
+    //Shader cache
+    std::unordered_map<uint64_t, CompiledShader> _shaderCache;
+
+    //Mutex for shader management - mutex cannot be moved
+    std::unique_ptr<std::mutex> _mutex = std::make_unique<std::mutex>();
+
+    CompiledShaderGroup() = default;
+    CompiledShaderGroup(CompiledShaderGroup&&) = default;
+    CompiledShaderGroup& operator=(CompiledShaderGroup&&) = default;
+
+    static CompiledShader ReadShader(winrt::Windows::Storage::Streams::DataReader& reader, bool headerOnly = false)
     {
-      using namespace winrt::Windows::Storage::Streams;
-
-      auto it = _uncompressedBlock->ShaderOffsets.find(key);
-      if (it != _uncompressedBlock->ShaderOffsets.end())
+      auto magic = ReadString(reader, 4);
+      if (magic != L"SH01")
       {
-        auto shaderPosition = it->second;
-        _uncompressedBlock->Block.Seek(shaderPosition);
-
-        DataReader dataReader{ _uncompressedBlock->Block };
-
-        auto shader = read_shader(dataReader);
-
-        dataReader.DetachStream();
-
-        auto [shaderIt, _] = _shadersByKey.emplace(key, std::move(shader));
-        return &shaderIt->second;
+        throw std::exception("Invalid compiled shader instance header.");
       }
-      else
+
+      CompiledShader shader;
+      ReadValue(reader, shader.Key);
+      ReadValue(reader, shader.Size);
+
+      if (!headerOnly)
       {
-        //Internal error, should not happen
-        throw std::exception("Shader not present.");
+        shader.ByteCode.resize(shader.Size);
+        ReadVector(reader, shader.ByteCode);
       }
+
+      return shader;
     }
 
-    const CompiledShader* LoadFromCompressedBlock(uint64_t blockIndex, const BlockInfo& blockInfo, uint64_t key)
+    void ActivateBlock(uint64_t blockKey)
     {
       using namespace winrt::Windows::Storage::Streams;
       using namespace winrt::Windows::Storage::Compression;
 
-      auto startPosition = _compressedBlocks.Position();
+      //Maybe the block is already loaded
+      if (_activeBlock && _activeBlock->Key == blockKey) return;
+
+      //Locate block info
+      auto& blockInfo = _shaderBlocks.at(blockKey);
 
       //Seek to the start of the compressed block
-      _compressedBlocks.Seek(startPosition + blockInfo.CompressedOffset);
+      _shaderStream.Seek(_blockOffset + blockInfo.CompressedOffset);
 
-      UncompressedBlock uncompressedBlock;
-      uncompressedBlock.Index = blockIndex;
+      ShaderBlock uncompressedBlock;
+      uncompressedBlock.Key = blockKey;
 
       //Decompress block
       {
         Buffer buffer{ 1024 * 1024 };
-        Decompressor decompressor{ _compressedBlocks };
+        Decompressor decompressor{ _shaderStream };
         do
         {
           AwaitOperation(decompressor.ReadAsync(buffer, buffer.Capacity(), InputStreamOptions::None));
@@ -196,48 +171,46 @@ namespace ShaderGenerator
         uncompressedBlock.Block.Seek(0);
       }
 
-      //Set up shader offsets and load the queried shader
-      CompiledShader* queriedShader = nullptr;
+      //Load shader offsets
       {
         DataReader dataReader{ uncompressedBlock.Block };
+        dataReader.ByteOrder(ByteOrder::LittleEndian);
 
         for (uint32_t i = 0; i < blockInfo.ShaderCount; ++i)
         {
           auto shaderStart = uncompressedBlock.Block.Position();
-          CompiledShader shader = read_shader(dataReader, true);
+          CompiledShader shader = ReadShader(dataReader, true);
 
-          if (shader.Key == key)
-          {
-            shader.ByteCode.resize(shader.Size);
-            read(dataReader, shader.ByteCode);
-            queriedShader = &_shadersByKey.emplace(key, std::move(shader)).first->second;
-          }
-          else
-          {
-            uncompressedBlock.ShaderOffsets[shader.Key] = shaderStart;
-            uncompressedBlock.Block.Seek(uncompressedBlock.Block.Position() + shader.Size);
-          }
+          uncompressedBlock.ShaderOffsets[shader.Key] = shaderStart;
+          uncompressedBlock.Block.Seek(uncompressedBlock.Block.Position() + shader.Size);
         }
 
         dataReader.DetachStream();
       }
 
-      //Seek back to the first block
-      _compressedBlocks.Seek(startPosition);
-
       //Replace the cached uncompressed block
-      _uncompressedBlock = std::move(uncompressedBlock);
+      _activeBlock = std::move(uncompressedBlock);
+    }
 
-      //Return the uncompressed shader
-      if (queriedShader)
-      {
-        return queriedShader;
-      }
-      else
-      {
-        //Internal error, should not happen
-        throw std::exception("Shader not present.");
-      }
+    CompiledShader LoadShader(uint64_t key)
+    {
+      using namespace winrt::Windows::Storage::Streams;
+
+      //Active the appropriate block
+      auto blockKey = key & _blockKeyMask;
+      ActivateBlock(blockKey);
+
+      //Load the shader
+      auto shaderOffset = _activeBlock->ShaderOffsets.at(key);
+      _activeBlock->Block.Seek(shaderOffset);
+
+      DataReader dataReader{ _activeBlock->Block };
+      dataReader.ByteOrder(ByteOrder::LittleEndian);
+      auto result = ReadShader(dataReader);
+      dataReader.DetachStream();
+
+      //Return the result
+      return result;
     }
 
   public:
@@ -245,7 +218,7 @@ namespace ShaderGenerator
     {
       for (auto& shader : shaders)
       {
-        _shadersByKey[shader.Key] = std::move(shader);
+        _shaderCache[shader.Key] = std::move(shader);
       }
     }
 
@@ -261,12 +234,12 @@ namespace ShaderGenerator
 
       try
       {
+        //Open file
         {
-          //Open file
           auto preferredPath = path;
           preferredPath.make_preferred();
 
-          StorageFile storageFile{nullptr};
+          StorageFile storageFile{ nullptr };
           if (IsUwp())
           {
             Uri uri{ L"ms-appx:///" + preferredPath };
@@ -277,41 +250,48 @@ namespace ShaderGenerator
             storageFile = AwaitResults(StorageFile::GetFileFromPathAsync(preferredPath.c_str()));
           }
 
-          result._compressedBlocks = AwaitResults(storageFile.OpenAsync(FileAccessMode::Read));
+          result._shaderStream = AwaitResults(storageFile.OpenAsync(FileAccessMode::Read));
         }
 
-        DataReader dataReader{ result._compressedBlocks };
-
-        //Check header
-        auto magic = read_string(dataReader, 4);
-        if (magic != L"CSG3")
+        //Parse file
         {
-          throw std::exception("Invalid compiled shader group file header.");
+          DataReader dataReader{ result._shaderStream };
+          dataReader.ByteOrder(ByteOrder::LittleEndian);
+
+          //Check header
+          auto magic = ReadString(dataReader, 4);
+          if (magic != L"CSG3")
+          {
+            throw std::exception("Invalid compiled shader group file header.");
+          }
+
+          //Read block index mask and block count
+          ReadValue(dataReader, result._blockKeyMask);
+          auto blockCount = ReadValue<uint32_t>(dataReader);
+
+          //Read block infos
+          result._shaderBlocks.reserve(blockCount);
+          for (uint32_t i = 0; i < blockCount; ++i)
+          {
+            auto key = ReadValue<uint64_t>(dataReader);
+
+            ShaderBlockInfo info;
+            ReadValue(dataReader, info.CompressedOffset);
+            ReadValue(dataReader, info.ShaderCount);
+
+            result._shaderBlocks[key] = info;
+          }
+
+          dataReader.DetachStream();
         }
 
-        //Read block index mask and block count
-        read(dataReader, result._blockIndexMask);
-        auto blockCount = read<uint32_t>(dataReader);
-       
-        //Read block infos
-        for (uint32_t i = 0; i < blockCount; ++i)
-        {
-          auto key = read<uint64_t>(dataReader);
-
-          BlockInfo info;
-          read(dataReader, info.ShaderCount);
-          read(dataReader, info.CompressedOffset);
-
-          result._blockInfos[key] = info;
-        }
-
-        dataReader.DetachStream();
+        result._blockOffset = result._shaderStream.Position();
       }
       catch (...)
       {
         //Return empty result
-        result._compressedBlocks = nullptr;
-        result._blockInfos.clear();
+        result._shaderStream = nullptr;
+        result._shaderBlocks.clear();
 
         throw std::exception("Failed to open compiled shader group file.");
       }
@@ -321,27 +301,24 @@ namespace ShaderGenerator
 
     const std::unordered_map<uint64_t, CompiledShader>& Shaders() const
     {
-      return _shadersByKey;
+      return _shaderCache;
     }
 
     const CompiledShader* Shader(uint64_t key)
     {
-      auto blockIndex = key & _blockIndexMask;
+      try
+      {
+        std::lock_guard lock(*_mutex);
 
-      if (auto shaderIt = _shadersByKey.find(key); shaderIt != _shadersByKey.end())
-      {
-        //Shader found in cache, return it
-        return &shaderIt->second;
+        auto& shader = _shaderCache[key];
+        if (!shader.Size)
+        {
+          shader = LoadShader(key);
+        }
+
+        return &shader;
       }
-      else if (_uncompressedBlock && _uncompressedBlock->Index == blockIndex)
-      {
-        return LoadFromUncompressedBlock(key);
-      }
-      else if (auto blockIt = _blockInfos.find(blockIndex); blockIt != _blockInfos.end() && _compressedBlocks)
-      {
-        return LoadFromCompressedBlock(blockIndex, blockIt->second, key);
-      }
-      else
+      catch (...)
       {
         return nullptr;
       }
@@ -355,8 +332,8 @@ namespace ShaderGenerator
 
     void ClearCache()
     {
-      _shadersByKey.clear();
-      _uncompressedBlock.reset();
+      _shaderCache.clear();
+      _activeBlock.reset();
     }
   };
 }

--- a/nuget/include/ShaderGenerator.h
+++ b/nuget/include/ShaderGenerator.h
@@ -196,7 +196,8 @@ namespace ShaderGenerator
         uncompressedBlock.Block.Seek(0);
       }
 
-      //Set up shader offsets
+      //Set up shader offsets and load the queried shader
+      CompiledShader* queriedShader = nullptr;
       {
         DataReader dataReader{ uncompressedBlock.Block };
 
@@ -209,7 +210,7 @@ namespace ShaderGenerator
           {
             shader.ByteCode.resize(shader.Size);
             read(dataReader, shader.ByteCode);
-            _shadersByKey.emplace(key, std::move(shader));
+            queriedShader = &_shadersByKey.emplace(key, std::move(shader)).first->second;
           }
           else
           {
@@ -228,10 +229,9 @@ namespace ShaderGenerator
       _uncompressedBlock = std::move(uncompressedBlock);
 
       //Return the uncompressed shader
-      auto it = _shadersByKey.find(key);
-      if (it != _shadersByKey.end())
+      if (queriedShader)
       {
-        return &it->second;
+        return queriedShader;
       }
       else
       {


### PR DESCRIPTION
Shader variants were previously put into chunks randomly and CompiledShaderGroup::FromFile decompressed every shader in the .csg file. I changed this behaviour: now the value of the first few options determine the compression block of the variant. This way only the block of the actually used shaders is decompressed at runtime. The block is cached, so similar variants can be later accessed faster.