### PR TITLE
Remove parallel std

### DIFF
--- a/ShaderGenerator/Parallel.h
+++ b/ShaderGenerator/Parallel.h
@@ -1,0 +1,73 @@
+#pragma once
+#include "pch.h"
+
+namespace ShaderGenerator
+{
+  template <class T, class U, class TItems = std::vector<T>>
+  std::vector<U> parallel_map(const TItems& items, std::function<U(const T&)> func, uint8_t threadCount = std::thread::hardware_concurrency())
+  {
+    typedef std::pair<const T*, size_t> item_t;
+    typedef std::pair<U, size_t> result_t;
+
+    std::queue<item_t> workItems;
+    size_t index = 0u;
+    for (auto& item : items)
+    {
+      workItems.push(item_t(&item, index++));
+    }
+
+    std::mutex workItemSync, resultSync;
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+    std::vector<result_t> results;
+    results.reserve(items.size());
+    for (size_t threadIndex = 0u; threadIndex < threadCount; threadIndex++)
+    {
+      auto threadFunc = [&workItems, &results, &workItemSync, &resultSync, func]() -> void {
+          item_t workItem;
+          while (true)
+          {
+            {
+              std::lock_guard<std::mutex> lock(workItemSync);
+              if (workItems.size() == 0u) break;
+
+              workItem = workItems.front();
+              workItems.pop();
+            }
+
+            auto result = func(*workItem.first);
+
+            {
+              std::lock_guard<std::mutex> lock(resultSync);
+              results.push_back(result_t(std::move(result), workItem.second));
+            }
+          }
+      };
+
+      threads.push_back(std::thread(threadFunc));
+    }
+
+    for (auto& thread : threads)
+    {
+      thread.join();
+    }
+
+    struct
+    {
+      bool operator ()(const result_t& a, const result_t& b)
+      {
+        return a.second < b.second;
+      }
+    } comparator;
+
+    sort(results.begin(), results.end(), comparator);
+
+    std::vector<U> sortedResults;
+    sortedResults.reserve(results.size());
+    for (auto& result : results)
+    {
+      sortedResults.push_back(std::move(result.first));
+    }
+    return sortedResults;
+  }
+}

--- a/ShaderGenerator/Parallel.h
+++ b/ShaderGenerator/Parallel.h
@@ -52,21 +52,10 @@ namespace ShaderGenerator
       thread.join();
     }
 
-    struct
-    {
-      bool operator ()(const result_t& a, const result_t& b)
-      {
-        return a.second < b.second;
-      }
-    } comparator;
-
-    sort(results.begin(), results.end(), comparator);
-
-    std::vector<U> sortedResults;
-    sortedResults.reserve(results.size());
+    std::vector<U> sortedResults(results.size());
     for (auto& result : results)
     {
-      sortedResults.push_back(std::move(result.first));
+      sortedResults[result.second] = std::move(result.first);
     }
     return sortedResults;
   }

--- a/ShaderGenerator/ShaderCompiler.cpp
+++ b/ShaderGenerator/ShaderCompiler.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "ShaderCompiler.h"
+#include "Parallel.h"
 
 using namespace std;
 using namespace winrt;
@@ -150,8 +151,7 @@ namespace ShaderGenerator
     if (options.IsDebug) printf(" with debug symbols");
     printf("...\n Generating %zu shader variants.\n", permutations.size());
 
-    context.Output.resize(context.Input->size());
-    transform(execution::par, context.Input->begin(), context.Input->end(), context.Output.begin(), 
+    context.Output = parallel_map<OptionPermutation, CompiledShader>(*context.Input,
       [&](const OptionPermutation& permutation) 
       { 
         return CompileShaderPermutation(permutation, context); 

--- a/ShaderGenerator/ShaderGenerator.vcxproj
+++ b/ShaderGenerator/ShaderGenerator.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,6 +105,7 @@
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdcpp20</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">copy $(OutDir)ShaderGenerator.exe $(SolutionDir)nuget\bin\ShaderGenerator.exe /y /b</Command>
@@ -115,6 +117,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/ShaderGenerator/ShaderGenerator.vcxproj
+++ b/ShaderGenerator/ShaderGenerator.vcxproj
@@ -132,6 +132,7 @@
   <ItemGroup>
     <ClInclude Include="FileAttributes.h" />
     <ClInclude Include="IO.h" />
+    <ClInclude Include="Parallel.h" />
     <ClInclude Include="ShaderCompilationArguments.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ShaderCompiler.h" />

--- a/ShaderGenerator/ShaderGenerator.vcxproj.filters
+++ b/ShaderGenerator/ShaderGenerator.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClInclude Include="IO.h">
       <Filter>Helpers</Filter>
     </ClInclude>
+    <ClInclude Include="Parallel.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/ShaderGenerator/ShaderOutputWriter.cpp
+++ b/ShaderGenerator/ShaderOutputWriter.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "ShaderOutputWriter.h"
 #include "IO.h"
+#include "Parallel.h"
 
 using namespace winrt;
 using namespace winrt::Windows::Storage;
@@ -133,8 +134,7 @@ namespace ShaderGenerator
       }
 
       //Run compression threads
-      vector<CompressionBlock> output(input.size());
-      transform(execution::par_unseq, input.begin(), input.end(), output.begin(),
+      vector<CompressionBlock> output = parallel_map<array_view<const CompiledShader>, CompressionBlock, vector<array_view<const CompiledShader>>>(input,
         [&](const auto& shaderBlock)
         {
           return CreateShaderBlock(shaderBlock, blockLayout);

--- a/ShaderGenerator/ShaderOutputWriter.cpp
+++ b/ShaderGenerator/ShaderOutputWriter.cpp
@@ -134,7 +134,7 @@ namespace ShaderGenerator
       }
 
       //Run compression threads
-      vector<CompressionBlock> output = parallel_map<array_view<const CompiledShader>, CompressionBlock, vector<array_view<const CompiledShader>>>(input,
+      auto output = parallel_map<array_view<const CompiledShader>, CompressionBlock>(input,
         [&](const auto& shaderBlock)
         {
           return CreateShaderBlock(shaderBlock, blockLayout);

--- a/ShaderGenerator/pch.h
+++ b/ShaderGenerator/pch.h
@@ -7,8 +7,7 @@
 #include <thread>
 #include <sstream>
 #include <unordered_set>
-#include <algorithm>
-#include <execution>
+#include <functional>
 
 #define NOMINMAX
 

--- a/nuget/ShaderGenerator.nuspec
+++ b/nuget/ShaderGenerator.nuspec
@@ -5,7 +5,7 @@
     <id>ShaderGenerator</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.0.39.0</version>
+    <version>1.0.40.0</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Péter Major</authors>
@@ -27,7 +27,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
     <!-- Any details about this particular release -->
-    <releaseNotes>Better error handling.</releaseNotes>
+    <releaseNotes>Improved system responsiveness during shader compilation.</releaseNotes>
 
     <!-- The description can be used in package manager UI. Note that the
              nuget.org gallery uses information you add in the portal. -->


### PR DESCRIPTION
Usage of parallel std::transform led to OS performance issues, refactored code to use std::thread based solution.